### PR TITLE
[FIX] - Ajout des dépendances manquantes dans les hooks useEffect

### DIFF
--- a/components/ui/tableConvertCenth.tsx
+++ b/components/ui/tableConvertCenth.tsx
@@ -129,7 +129,7 @@ export default function TableConvertCenth() {
       toPDF();
     }
     setDocumentType(null);
-  }, [documentType]);
+  }, [documentType, handlePrint, toPDF]);
 
   return (
     <div>

--- a/components/ui/tableConvertHours.tsx
+++ b/components/ui/tableConvertHours.tsx
@@ -128,7 +128,7 @@ export default function TableConvertHours() {
       toPDF();
     }
     setDocumentType(null);
-  }, [documentType]);
+  }, [documentType, handlePrint, toPDF]);
 
   return (
     <div>

--- a/components/ui/tableHours.tsx
+++ b/components/ui/tableHours.tsx
@@ -139,7 +139,7 @@ export default function TableHours() {
       toPDF();
     }
     setDocumentType(null);
-  }, [documentType]);
+  }, [documentType, handlePrint, toPDF]);
 
   return (
     <div>


### PR DESCRIPTION
**Contexte:**

Correction des avertissements ESLint concernant les dépendances manquantes dans les hooks useEffect de plusieurs composants. Ces avertissements indiquaient que certaines fonctions utilisées dans les effets n'étaient pas déclarées comme dépendances.

**Changements**

- Ajout des dépendances manquantes handlePrint et toPDF dans le tableau de dépendances du hook useEffect de tableConvertCenth.tsx
- Ajout des dépendances manquantes handlePrint et toPDF dans le tableau de dépendances du hook useEffect de 
tableConvertHours.tsx
- Ajout des dépendances manquantes handlePrint et toPDF dans le tableau de dépendances du hook useEffect de tableHours.tsx 

**Tests effectués**

- Vérification de l'absence d'avertissements ESLint liés aux dépendances manquantes
- Vérification du bon fonctionnement des fonctionnalités d'impression et d'export PDF
